### PR TITLE
copying dom list so that injecting tokens doesn't mess up iteration. #35

### DIFF
--- a/csrfguard/src/main/resources/csrfguard.js
+++ b/csrfguard/src/main/resources/csrfguard.js
@@ -332,7 +332,8 @@
 		}
 
 		/** iterate over all elements and injection token **/
-		var all = document.all ? document.all : document.getElementsByTagName('*');
+		var temp = document.all ? document.all : document.getElementsByTagName('*');
+		var all = Array.from(temp);
 		var len = all.length;
 
 		for(var i=0; i<len; i++) {


### PR DESCRIPTION
If you're injecting hidden tokens into this list, "all" gets longer during the iteration but "len" stays the same, so you'll miss any additional forms that are far enough down the dom. I can work up an example if you want.